### PR TITLE
Deploy to Cloudflare Workers (Jekyll static site)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "stout-dog",
+  "compatibility_date": "2026-03-20",
+  "assets": {
+    "directory": "./_site"
+  }
+}


### PR DESCRIPTION
Add wrangler.jsonc to deploy the Jekyll site to Cloudflare Workers. Jekyll builds to `_site/` which Cloudflare serves as static assets. Same pattern as the profile repo.